### PR TITLE
Fix the tagging of main

### DIFF
--- a/.github/workflows/ci-main.yaml
+++ b/.github/workflows/ci-main.yaml
@@ -96,5 +96,5 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: release_${{ needs.bump-tag-version.outputs.semver_next }}.zip
           asset_name: release_${{ needs.bump-tag-version.outputs.semver_next }}.zip
-          tag: ${{ github.ref }}
+          tag: ${{ needs.bump-tag-version.outputs.semver_next }}
           overwrite: true


### PR DESCRIPTION
# Release Notes:
- Fix the creation of a `main` tag and a secondary release off of the intended release
<sub>_End Release Notes_</sub>